### PR TITLE
More general regression test for determinant calculation + operator= bugfix

### DIFF
--- a/src/Utility/Tensor.C
+++ b/src/Utility/Tensor.C
@@ -308,8 +308,14 @@ Tensor& Tensor::operator= (const Tensor& T)
       for (t_ind j = (this->symmetric() ? i : 1); j <= ndim; j++)
         v[this->index(i,j)] = T(i,j);
 
-    if (this->symmetric() && v.size() == 4 && T.v.size() >= 4)
-      v[2] = T(3,3);
+    if (this->symmetric() && T.v.size() >= 4)
+    {
+      if (v.size() == 4) v[2] = T(3,3);
+    }
+    else
+    {
+      if (v.size() == 9) v[8] = T(3,3);
+    }
   }
 
   return *this;
@@ -924,7 +930,7 @@ Real SymmTensor::det () const
       - v[3]*(v[3]*v[2] - v[5]*v[4])
       + v[5]*(v[3]*v[4] - v[5]*v[1]);
   else if (n == 2)
-    d = v.front() * v[1] - v.back() * v.back();
+    d = v.front()*v[1] - v.back()*v.back();
   else if (n == 1)
     d = v.front();
 

--- a/src/Utility/Test/TestTensor.C
+++ b/src/Utility/Test/TestTensor.C
@@ -277,3 +277,27 @@ TEST(TestTensor, Determinant)
   EXPECT_FLOAT_EQ(T2.det(), -2.0);
   EXPECT_FLOAT_EQ(T3.det(), 0.0);
 }
+
+
+TEST(TestTensor, Det)
+{
+  const double data[9] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0 };
+
+  SymmTensor S0(std::vector<double>(data,data+1));
+  SymmTensor S1(std::vector<double>(data,data+3));
+  SymmTensor S2(std::vector<double>(data,data+4));
+  SymmTensor S3(std::vector<double>(data,data+6));
+
+  EXPECT_EQ(S0.dim(),1);
+  EXPECT_EQ(S1.dim(),2);
+  EXPECT_EQ(S2.dim(),2);
+  EXPECT_EQ(S3.dim(),3);
+
+  Tensor T0(1), T1(2), T2(3), T3(3);
+  T0 = S0; T1 = S1; T2 = S2; T3 = S3;
+
+  EXPECT_FLOAT_EQ(S0.det(),T0.det());
+  EXPECT_FLOAT_EQ(S1.det(),T1.det());
+  EXPECT_FLOAT_EQ(S2.det(),T2.det());
+  EXPECT_FLOAT_EQ(S3.det(),T3.det());
+}


### PR DESCRIPTION
Here is my contribution. It also fixes the assignment operator in the (rare) case of assigning a 2D SymmTensor object with either plane-strain or axi-symmtry (such that we have the zz-term) to a general 3D Tensor. This is used in one of the new tests, but probably not elsewhere, yet.